### PR TITLE
Add missing params to accounting routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,8 @@ jobs:
 
     publish:
         name: Publish
-        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v')
         runs-on: ubuntu-latest
-        needs: test
         steps:
             - name: Checkout
               uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,26 @@
 -   [SYNC] Add create sync
 -   [SYNC] Add update sync
 -   [CONSUMER] Add enable consumer flow
+
+## 1.0.8 - 2024-04-04
+
+-   [ACCOUNTING] Add params to getAnalyticPlans
+-   [ACCOUNTING] Add params to getClients
+-   [ACCOUNTING] Add params to getClient
+-   [ACCOUNTING] Add params to updateClient
+-   [ACCOUNTING] Add params to getSuppliers
+-   [ACCOUNTING] Add params to getSupplier
+-   [ACCOUNTING] Add params to updateSupplier
+-   [ACCOUNTING] Add params to createAnalyticAccount
+-   [ACCOUNTING] Add params to getAnalyticAccounts
+-   [ACCOUNTING] Add params to createAnalyticAccountWithMultiplePlans
+-   [ACCOUNTING] Add params to getAnalyticAccount
+-   [ACCOUNTING] Add params to updateAnalyticAccount
+-   [ACCOUNTING] Add params to getAnalyticAccountWithMultiplePlans
+-   [ACCOUNTING] Add params to getAnalyticAccountsWithMultiplePlans
+-   [ACCOUNTING] Add params to updateAnalyticAccountWithMultiplePlans
+-   [ACCOUNTING] Add params to getPaymentsByInvoiceId
+-   [ACCOUNTING] Add params to getJournals
+-   [ACCOUNTING] Add params to getVatCodes
+-   [ACCOUNTING] Add route getAttachments
+-   [ACCOUNTING] Add route matchEntries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,3 +72,4 @@
 -   [ACCOUNTING] Add params to getVatCodes
 -   [ACCOUNTING] Add route getAttachments
 -   [ACCOUNTING] Add route matchEntries
+-   [ACCOUNTING] Add route getFolders

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@chift/chift-nodejs",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@chift/chift-nodejs",
-            "version": "1.0.7",
+            "version": "1.0.8",
             "license": "Apache License 2.0",
             "dependencies": {
                 "axios": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@chift/chift-nodejs",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "description": "The Chift NodeJS library provides convenient access to the Chift API from applications written in the NodeJS language (Javascript/Typescript).",
     "main": "dist/src/index.js",
     "types": "dist/src/index.d.ts",

--- a/src/modules/accounting.ts
+++ b/src/modules/accounting.ts
@@ -37,14 +37,20 @@ type getOutstandingsParams = Omit<
 >;
 
 const accountingFactory = {
-    getAnalyticPlans(): RequestData<components['schemas']['AnalyticPlanItem'][]> {
+    getAnalyticPlans(
+        params: operations['accounting_get_analytic_plans']['parameters']['query']
+    ): RequestData<components['schemas']['AnalyticPlanItem'][]> {
         return {
+            params,
             method: 'get',
             url: '/consumers/{consumer_id}/accounting/analytic-plans',
         };
     },
-    getClients(): RequestData<components['schemas']['ClientItemOut'][]> {
+    getClients(
+        params: operations['accounting_get_clients']['parameters']['query']
+    ): RequestData<components['schemas']['ClientItemOut'][]> {
         return {
+            params,
             method: 'get',
             url: '/consumers/{consumer_id}/accounting/clients',
         };
@@ -54,30 +60,39 @@ const accountingFactory = {
         params: operations['accounting_create_client']['parameters']['query']
     ): RequestData<components['schemas']['ClientItemOut']> {
         return {
+            params,
             method: 'post',
             url: '/consumers/{consumer_id}/accounting/clients',
             body: client,
-            params: params,
         };
     },
-    getClient(clientId: string): RequestData<components['schemas']['ClientItemOut']> {
+    getClient(
+        clientId: string,
+        params: operations['accounting_get_client']['parameters']['query']
+    ): RequestData<components['schemas']['ClientItemOut']> {
         return {
+            params,
             method: 'get',
             url: `/consumers/{consumer_id}/accounting/clients/${clientId}`,
         };
     },
     updateClient(
         clientId: string,
-        client: components['schemas']['ClientItemUpdate']
+        client: components['schemas']['ClientItemUpdate'],
+        params: operations['accounting_update_client']['parameters']['query']
     ): RequestData<components['schemas']['ClientItemOut']> {
         return {
+            params,
             method: 'patch',
             url: `/consumers/{consumer_id}/accounting/clients/${clientId}`,
             body: client,
         };
     },
-    getSuppliers(): RequestData<components['schemas']['SupplierItemOut'][]> {
+    getSuppliers(
+        params: operations['accounting_get_suppliers']['parameters']['query']
+    ): RequestData<components['schemas']['SupplierItemOut'][]> {
         return {
+            params,
             method: 'get',
             url: '/consumers/{consumer_id}/accounting/suppliers',
         };
@@ -87,23 +102,29 @@ const accountingFactory = {
         params: operations['accounting_create_supplier']['parameters']['query']
     ): RequestData<components['schemas']['SupplierItemOut']> {
         return {
+            params,
             method: 'post',
             url: '/consumers/{consumer_id}/accounting/suppliers',
             body: supplier,
-            params: params,
         };
     },
-    getSupplier(supplierId: string): RequestData<components['schemas']['SupplierItemOut']> {
+    getSupplier(
+        supplierId: string,
+        params: operations['accounting_get_supplier']['parameters']['query']
+    ): RequestData<components['schemas']['SupplierItemOut']> {
         return {
+            params,
             method: 'get',
             url: `/consumers/{consumer_id}/accounting/suppliers/${supplierId}`,
         };
     },
     updateSupplier(
         supplierId: string,
-        supplier: components['schemas']['SupplierItemUpdate']
+        supplier: components['schemas']['SupplierItemUpdate'],
+        params: operations['accounting_update_supplier']['parameters']['query']
     ): RequestData<components['schemas']['SupplierItemOut']> {
         return {
+            params,
             method: 'patch',
             url: `/consumers/{consumer_id}/accounting/suppliers/${supplierId}`,
             body: supplier,
@@ -172,43 +193,54 @@ const accountingFactory = {
         };
     },
     createAnalyticAccount(
-        analyticAccount: components['schemas']['AnalyticAccountItemIn']
+        analyticAccount: components['schemas']['AnalyticAccountItemIn'],
+        params: operations['accounting_create_analytic_account']['parameters']['query']
     ): RequestData<components['schemas']['AnalyticAccountItemOut']> {
         return {
+            params,
             method: 'post',
             url: '/consumers/{consumer_id}/accounting/analytic-accounts',
             body: analyticAccount,
         };
     },
-    getAnalyticAccounts(): RequestData<components['schemas']['AnalyticAccountItemOut'][]> {
+    getAnalyticAccounts(
+        params: operations['accounting_get_analytic_accounts']['parameters']['query']
+    ): RequestData<components['schemas']['AnalyticAccountItemOut'][]> {
         return {
+            params,
             method: 'get',
             url: '/consumers/{consumer_id}/accounting/analytic-accounts',
         };
     },
     createAnalyticAccountWithMultiplePlans(
         analytic_plan: string,
-        analyticAccount: components['schemas']['AnalyticAccountItemIn']
+        analyticAccount: components['schemas']['AnalyticAccountItemIn'],
+        params: operations['accounting_create_analytic_account_multi_plans']['parameters']['query']
     ): RequestData<components['schemas']['AnalyticAccountItemOutMultiAnalyticPlans']> {
         return {
+            params,
             method: 'post',
             url: `/consumers/{consumer_id}/accounting/analytic-accounts/multi-analytic-plans/${analytic_plan}`,
             body: analyticAccount,
         };
     },
     getAnalyticAccount(
-        analytic_account_id: string
+        analytic_account_id: string,
+        params: operations['accounting_get_analytic_account']['parameters']['query']
     ): RequestData<components['schemas']['AnalyticAccountItemOut']> {
         return {
+            params,
             method: 'get',
             url: `/consumers/{consumer_id}/accounting/analytic-accounts/${analytic_account_id}`,
         };
     },
     updateAnalyticAccount(
         analytic_account_id: string,
-        analyticAccount: components['schemas']['AnalyticAccountItemUpdate']
+        analyticAccount: components['schemas']['AnalyticAccountItemUpdate'],
+        params: operations['accounting_update_analytic_account']['parameters']['query']
     ): RequestData<components['schemas']['AnalyticAccountItemOut']> {
         return {
+            params,
             method: 'patch',
             url: `/consumers/{consumer_id}/accounting/analytic-accounts/${analytic_account_id}`,
             body: analyticAccount,
@@ -216,9 +248,11 @@ const accountingFactory = {
     },
     getAnalyticAccountWithMultiplePlans(
         analytic_account_id: string,
-        analytic_plan: string
+        analytic_plan: string,
+        params: operations['accounting_get_analytic_account_multi_plans']['parameters']['query']
     ): RequestData<components['schemas']['AnalyticAccountItemOutMultiAnalyticPlans']> {
         return {
+            params,
             method: 'get',
             url: `/consumers/{consumer_id}/accounting/analytic-accounts/${analytic_account_id}/multi-analytic-plans/${analytic_plan}`,
         };
@@ -226,18 +260,21 @@ const accountingFactory = {
     updateAnalyticAccountWithMultiplePlans(
         analytic_account_id: string,
         analytic_plan: string,
-        analyticAccount: components['schemas']['AnalyticAccountItemUpdate']
+        analyticAccount: components['schemas']['AnalyticAccountItemUpdate'],
+        params: operations['accounting_update_analytic_account_multi_plans']['parameters']['query']
     ): RequestData<components['schemas']['AnalyticAccountItemOutMultiAnalyticPlans']> {
         return {
+            params,
             method: 'patch',
             url: `/consumers/{consumer_id}/accounting/analytic-accounts/${analytic_account_id}/multi-analytic-plans/${analytic_plan}`,
             body: analyticAccount,
         };
     },
-    getAnalyticAccountsWithMultiplePlans(): RequestData<
-        components['schemas']['AnalyticAccountItemOutMultiAnalyticPlans'][]
-    > {
+    getAnalyticAccountsWithMultiplePlans(
+        params: operations['accounting_get_analytic_accounts_multi_plans']['parameters']['query']
+    ): RequestData<components['schemas']['AnalyticAccountItemOutMultiAnalyticPlans'][]> {
         return {
+            params,
             method: 'get',
             url: '/consumers/{consumer_id}/accounting/analytic-accounts/multi-analytic-plans',
         };
@@ -260,20 +297,30 @@ const accountingFactory = {
             url: `/consumers/{consumer_id}/accounting/journal/entries/multi-analytic-plans`,
         };
     },
-    getPaymentsByInvoiceId(invoice_id: string): RequestData<components['schemas']['Payment'][]> {
+    getPaymentsByInvoiceId(
+        invoice_id: string,
+        params: operations['accounting_get_payments_by_invoice']['parameters']['query']
+    ): RequestData<components['schemas']['Payment'][]> {
         return {
+            params,
             method: 'get',
             url: `/consumers/{consumer_id}/accounting/invoices/id/${invoice_id}/payments`,
         };
     },
-    getJournals(): RequestData<components['schemas']['Journal'][]> {
+    getJournals(
+        params: operations['accounting_get_journals']['parameters']['query']
+    ): RequestData<components['schemas']['Journal'][]> {
         return {
+            params,
             method: 'get',
             url: `/consumers/{consumer_id}/accounting/journals`,
         };
     },
-    getVatCodes(): RequestData<components['schemas']['app__routers__accounting__VatCode'][]> {
+    getVatCodes(
+        params: operations['accounting_get_vat_codes']['parameters']['query']
+    ): RequestData<components['schemas']['app__routers__accounting__VatCode'][]> {
         return {
+            params,
             method: 'get',
             url: `/consumers/{consumer_id}/accounting/vat-codes`,
         };
@@ -318,6 +365,15 @@ const accountingFactory = {
             method: 'post',
             url: `/consumers/{consumer_id}/accounting/invoices/pdf/${invoice_id}`,
             body: attachment,
+        };
+    },
+    getAttachments(
+        params: operations['accounting_get_attachments']['parameters']['query']
+    ): RequestData<components['schemas']['AttachmentItem'][]> {
+        return {
+            params,
+            method: 'get',
+            url: `/consumers/{consumer_id}/accounting/attachments`,
         };
     },
     getChartOfAccounts(
@@ -401,6 +457,17 @@ const accountingFactory = {
             method: 'post',
             url: '/consumers/{consumer_id}/accounting/journal-entries',
             body: journal_entry,
+        };
+    },
+    matchEntries(
+        body: components['schemas']['MatchingIn'],
+        params: operations['accounting_match_entries']['parameters']['query']
+    ): RequestData<components['schemas']['MatchingOut']> {
+        return {
+            params,
+            body,
+            method: 'post',
+            url: '/consumers/{consumer_id}/accounting/matching',
         };
     },
 };

--- a/src/modules/accounting.ts
+++ b/src/modules/accounting.ts
@@ -470,6 +470,12 @@ const accountingFactory = {
             url: '/consumers/{consumer_id}/accounting/matching',
         };
     },
+    getFolders(): RequestData<components['schemas']['FolderItem'][]> {
+        return {
+            method: 'get',
+            url: '/consumers/{consumer_id}/accounting/folders',
+        };
+    },
 };
 
 export { accountingFactory };

--- a/test/modules/accounting.test.ts
+++ b/test/modules/accounting.test.ts
@@ -595,3 +595,34 @@ test('createFinancialEntryOld', async () => {
     expect(financialEntry).toBeTruthy();
     expect(financialEntry).toHaveProperty('journal_id', journal.id);
 });
+
+let folders: components['schemas']['FolderItem'][] = [];
+test('getFolders', async () => {
+    folders = await consumer.accounting.getFolders();
+    expect(folders).toBeInstanceOf(Array);
+    expect(folders.length).toBeGreaterThan(0);
+    expect(folders[0]).toHaveProperty('id', expect.any(String));
+    expect(folders[0]).toHaveProperty('name', expect.any(String));
+});
+
+test.skip('getAttachments', async () => {
+    const attachments = await consumer.accounting.getAttachments({
+        // TODO: Add documentId from test account
+        documentId: '',
+        type: 'invoice',
+    });
+    expect(attachments).toBeInstanceOf(Array);
+    expect(attachments.length).toBeGreaterThan(0);
+    expect(attachments[0]).toHaveProperty('id', expect.any(String));
+    expect(attachments[0]).toHaveProperty('base64_string', expect.any(String));
+});
+
+test.skip('matchEntries', async () => {
+    const match = await consumer.accounting.matchEntries({
+        // TODO: Change params with test account values
+        entries: [],
+        partner_id: '',
+    });
+    expect(match).toHaveProperty('matching_number', expect.any(String));
+    expect(match).toHaveProperty('balance', expect.any(Number));
+});


### PR DESCRIPTION
-   [ACCOUNTING] Add params to getAnalyticPlans
-   [ACCOUNTING] Add params to getClients
-   [ACCOUNTING] Add params to getClient
-   [ACCOUNTING] Add params to updateClient
-   [ACCOUNTING] Add params to getSuppliers
-   [ACCOUNTING] Add params to getSupplier
-   [ACCOUNTING] Add params to updateSupplier
-   [ACCOUNTING] Add params to createAnalyticAccount
-   [ACCOUNTING] Add params to getAnalyticAccounts
-   [ACCOUNTING] Add params to createAnalyticAccountWithMultiplePlans
-   [ACCOUNTING] Add params to getAnalyticAccount
-   [ACCOUNTING] Add params to updateAnalyticAccount
-   [ACCOUNTING] Add params to getAnalyticAccountWithMultiplePlans
-   [ACCOUNTING] Add params to getAnalyticAccountsWithMultiplePlans
-   [ACCOUNTING] Add params to updateAnalyticAccountWithMultiplePlans
-   [ACCOUNTING] Add params to getPaymentsByInvoiceId
-   [ACCOUNTING] Add params to getJournals
-   [ACCOUNTING] Add params to getVatCodes
-   [ACCOUNTING] Add route getAttachments
-   [ACCOUNTING] Add route matchEntries
-   [ACCOUNTING] Add route getFolders