### PR TITLE
connectionId and integrationId headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,3 +77,8 @@
 ## 1.0.9 - 2024-04-04
 
 -   Add getIntegrations params
+
+## 1.0.13 - 2024-05-07
+
+-   Add X-Chift-ConnectionId header
+-   Add X-Chift-IntegrationId header

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@chift/chift-nodejs",
-    "version": "1.0.9",
+    "version": "1.0.13",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@chift/chift-nodejs",
-            "version": "1.0.9",
+            "version": "1.0.13",
             "license": "Apache License 2.0",
             "dependencies": {
                 "axios": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@chift/chift-nodejs",
-    "version": "1.0.11",
+    "version": "1.0.13",
     "description": "The Chift NodeJS library provides convenient access to the Chift API from applications written in the NodeJS language (Javascript/Typescript).",
     "main": "dist/src/index.js",
     "types": "dist/src/index.d.ts",

--- a/src/modules/consumer.ts
+++ b/src/modules/consumer.ts
@@ -26,6 +26,14 @@ const Consumer = (
     const ecommerce = createApiFor(ecommerceFactory, _internalApi, data.name, consumerId);
     const custom = createApiFor(customFactory, _internalApi, data.name, consumerId);
 
+    const setConnectionId = async (connectionId: string) => {
+        _internalApi.connectionId = connectionId;
+    };
+
+    const setIntegrationId = async (integrationId: string) => {
+        _internalApi.integrationId = integrationId;
+    };
+
     const getConnections = async () => {
         const {
             data,
@@ -192,6 +200,8 @@ const Consumer = (
         updateDataStoreData,
         deleteDataStoreData,
         logData,
+        setConnectionId,
+        setIntegrationId,
     };
 };
 

--- a/src/modules/internalApi.ts
+++ b/src/modules/internalApi.ts
@@ -8,6 +8,8 @@ class InternalAPI {
     token?: TokenType;
     debug = false;
     relatedChainExecutionId?: string;
+    connectionId?: string;
+    integrationId?: string;
     get;
     post;
     patch;
@@ -27,10 +29,19 @@ class InternalAPI {
         this.instance.interceptors.request.use(
             (config) => {
                 return new Promise((resolve, reject) => {
+                    if (this.connectionId) {
+                        config.headers['X-Chift-ConnectionId'] = this.connectionId;
+                    }
+
+                    if (this.integrationId) {
+                        config.headers['X-Chift-IntegrationId'] = this.integrationId;
+                    }
+
                     if (this.relatedChainExecutionId) {
                         config.headers['X-Chift-RelatedChainExecutionId'] =
                             this.relatedChainExecutionId;
                     }
+
                     if (this.token) {
                         if (this.token?.expires_on < new Date().getTime()) {
                             return this.getToken()


### PR DESCRIPTION
call consumer.setConnectionId(connectionId:string) or consumer.setIntegrationId(integrationId:string) and you should be good to go 🏄‍♀️