### PR TITLE
fix: _setup shouldn'be a promise since he is used in constructor and …

### DIFF
--- a/src/modules/api.ts
+++ b/src/modules/api.ts
@@ -29,7 +29,7 @@ export class API {
         this.Issues = Issues(this.internalApi);
     }
 
-    private _setup = async () => {
+    private _setup = () => {
         if (!this.auth.clientId || !this.auth.clientSecret || !this.auth.accountId) {
             throw new Error('Missing mandatory auth parameters');
         }


### PR DESCRIPTION
Hello, while reading the code I noticed something a bit surprising.

`_setup()` is marked as `async`, but it only validates auth parameters and creates `InternalAPI`. Since constructors cannot `await` async initialization, the constructor calls it without awaiting it.

This means setup errors may surface as promise rejections instead of regular constructor errors, which can make stack traces misleading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-method signature change with no new logic; lowers risk of misleading error handling during client construction.
> 
> **Overview**
> Removes **`async`** from **`API._setup`** so initialization runs synchronously when the **`API`** constructor calls it.
> 
> Auth validation and **`InternalAPI`** creation were already synchronous; the async wrapper meant failures could surface as unhandled promise rejections instead of normal constructor errors. Behavior is unchanged aside from synchronous error propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74399767dd6432c7eeb09255301da324730448c5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->