### PR TITLE
fix: remove stop-after

### DIFF
--- a/.github/workflows/daily-schema-update.lock.yml
+++ b/.github/workflows/daily-schema-update.lock.yml
@@ -22,15 +22,14 @@
 # This workflow acts as an autonomous engineer responsible for keeping
 # the OpenAPI schemas and modules up to date.
 #
-# frontmatter-hash: a8109a3448c0dce48a63d0096262d003400e8cc68511ccbae9dc28752158cbed
-#
-# Effective stop-time: 2026-02-23 14:37:04
+# frontmatter-hash: f98dbb8063268838dc8411e43bcf283c5d7c7bcd11cbb9b4a6cd3cf22f73edd0
 
 name: "Agentic OpenAPI Schema Maintainer"
 "on":
   schedule:
   - cron: "56 4 * * *"
-  workflow_dispatch: null
+    # Friendly format: daily (scattered)
+  workflow_dispatch:
 
 permissions: {}
 
@@ -41,8 +40,6 @@ run-name: "Agentic OpenAPI Schema Maintainer"
 
 jobs:
   activation:
-    needs: pre_activation
-    if: needs.pre_activation.outputs.activated == 'true'
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -1037,28 +1034,6 @@ jobs:
           name: threat-detection.log
           path: /tmp/gh-aw/threat-detection/detection.log
           if-no-files-found: ignore
-
-  pre_activation:
-    runs-on: ubuntu-slim
-    outputs:
-      activated: ${{ steps.check_stop_time.outputs.stop_time_ok == 'true' }}
-    steps:
-      - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@15d0e133ebb103ed42485353efea00d7c8c07304 # v0.42.16
-        with:
-          destination: /opt/gh-aw/actions
-      - name: Check stop-time limit
-        id: check_stop_time
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        env:
-          GH_AW_STOP_TIME: 2026-02-23 14:37:04
-          GH_AW_WORKFLOW_NAME: "Agentic OpenAPI Schema Maintainer"
-        with:
-          script: |
-            const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io);
-            const { main } = require('/opt/gh-aw/actions/check_stop_time.cjs');
-            await main();
 
   safe_outputs:
     needs:

--- a/.github/workflows/daily-schema-update.md
+++ b/.github/workflows/daily-schema-update.md
@@ -6,7 +6,6 @@ description: |
 on:
     schedule: daily
     workflow_dispatch:
-    stop-after: +2w
 
 permissions: read-all
 
@@ -29,7 +28,7 @@ safe-outputs:
 steps:
     - name: Expand sparse checkout for schema and module updates
       run: |
-        git sparse-checkout add src test package.json package-lock.json tsconfig.json CHANGELOG.md
+          git sparse-checkout add src test package.json package-lock.json tsconfig.json CHANGELOG.md
 
 timeout-minutes: 20
 ---


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only gh-aw config change; main effect is the agentic maintainer keeps running on schedule instead of auto-disabling after two weeks.
> 
> **Overview**
> Removes the **`stop-after: +2w`** setting from the Agentic OpenAPI Schema Maintainer gh-aw source (`.github/workflows/daily-schema-update.md`), so the daily schedule and manual dispatch are no longer capped by a two-week cutoff.
> 
> Recompiling the lock workflow drops the **`pre_activation`** job and the **`check_stop_time`** gate that blocked **`activation`** after the configured stop time. **`activation`** now runs directly on each trigger instead of depending on `needs.pre_activation.outputs.activated`.
> 
> The compiled YAML also picks up minor gh-aw output tweaks (frontmatter hash, schedule/`workflow_dispatch` formatting). The sparse-checkout step line is unchanged aside from whitespace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65ab85db447f7d8f1de0cdbf4e2c8b29b6a19507. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->