### PR TITLE
Qg/fix agent workflow sparse checkout

### DIFF
--- a/.github/workflows/daily-schema-update.lock.yml
+++ b/.github/workflows/daily-schema-update.lock.yml
@@ -22,7 +22,7 @@
 # This workflow acts as an autonomous engineer responsible for keeping
 # the OpenAPI schemas and modules up to date.
 #
-# frontmatter-hash: e27469bdba8821e0b98072b0fbb9d033ebecf025cae650a9187353c680421de4
+# frontmatter-hash: 47305ae5807160a64f7a83ec6cb276f284cdc661d42364dabbee3c21670ac1d4
 
 name: "Agentic OpenAPI Schema Maintainer"
 "on":
@@ -37,6 +37,9 @@ concurrency:
   group: "gh-aw-${{ github.workflow }}"
 
 run-name: "Agentic OpenAPI Schema Maintainer"
+
+env:
+  HUSKY: "0"
 
 jobs:
   activation:
@@ -100,7 +103,7 @@ jobs:
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
       - name: Expand sparse checkout for schema and module updates
-        run: "git sparse-checkout add src test\ngit checkout HEAD -- package.json package-lock.json tsconfig.json CHANGELOG.md\n"
+        run: "git sparse-checkout add src test\ngit checkout HEAD -- \\\n  README.md \\\n  package.json \\\n  package-lock.json \\\n  tsconfig.json \\\n  CHANGELOG.md \\\n  .nvmrc\n"
 
       - name: Configure Git credentials
         env:

--- a/.github/workflows/daily-schema-update.lock.yml
+++ b/.github/workflows/daily-schema-update.lock.yml
@@ -22,7 +22,7 @@
 # This workflow acts as an autonomous engineer responsible for keeping
 # the OpenAPI schemas and modules up to date.
 #
-# frontmatter-hash: f98dbb8063268838dc8411e43bcf283c5d7c7bcd11cbb9b4a6cd3cf22f73edd0
+# frontmatter-hash: e27469bdba8821e0b98072b0fbb9d033ebecf025cae650a9187353c680421de4
 
 name: "Agentic OpenAPI Schema Maintainer"
 "on":
@@ -100,7 +100,7 @@ jobs:
       - name: Create gh-aw temp directory
         run: bash /opt/gh-aw/actions/create_gh_aw_tmp_dir.sh
       - name: Expand sparse checkout for schema and module updates
-        run: git sparse-checkout add src test package.json package-lock.json tsconfig.json CHANGELOG.md
+        run: "git sparse-checkout add src test\ngit checkout HEAD -- package.json package-lock.json tsconfig.json CHANGELOG.md\n"
 
       - name: Configure Git credentials
         env:

--- a/.github/workflows/daily-schema-update.md
+++ b/.github/workflows/daily-schema-update.md
@@ -28,7 +28,8 @@ safe-outputs:
 steps:
     - name: Expand sparse checkout for schema and module updates
       run: |
-          git sparse-checkout add src test package.json package-lock.json tsconfig.json CHANGELOG.md
+          git sparse-checkout add src test
+          git checkout HEAD -- package.json package-lock.json tsconfig.json CHANGELOG.md
 
 timeout-minutes: 20
 ---

--- a/.github/workflows/daily-schema-update.md
+++ b/.github/workflows/daily-schema-update.md
@@ -9,6 +9,9 @@ on:
 
 permissions: read-all
 
+env:
+    HUSKY: '0'
+
 network:
     allowed:
         - defaults
@@ -29,7 +32,13 @@ steps:
     - name: Expand sparse checkout for schema and module updates
       run: |
           git sparse-checkout add src test
-          git checkout HEAD -- package.json package-lock.json tsconfig.json CHANGELOG.md
+          git checkout HEAD -- \
+            README.md \
+            package.json \
+            package-lock.json \
+            tsconfig.json \
+            CHANGELOG.md \
+            .nvmrc
 
 timeout-minutes: 20
 ---


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only gh-aw workflow checkout and env changes; no application runtime or auth logic.
> 
> **Overview**
> Fixes the **Agentic OpenAPI Schema Maintainer** gh-aw workflow so the agent job gets the right tree after the initial minimal sparse checkout.
> 
> The expand step now only **adds** `src` and `test` to sparse-checkout, then **checks out** root files (`README.md`, `package.json`, `package-lock.json`, `tsconfig.json`, `CHANGELOG.md`, `.nvmrc`) from `HEAD` instead of listing those paths in a single `sparse-checkout add` line. The compiled `daily-schema-update.lock.yml` and frontmatter hash are updated to match.
> 
> Workflow-level **`HUSKY: '0'`** is added so npm lifecycle hooks (e.g. `prepare` → `husky install`) do not run in CI when dependencies are installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0b4651231f305e18728d6acb9ff7a6180f99975. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->